### PR TITLE
Fix cart interaction for product pages

### DIFF
--- a/Product.jsx
+++ b/Product.jsx
@@ -18,9 +18,11 @@ import {
 } from 'lucide-react'
 import { getProductById, products } from '../data/products'
 import ProductCard from '../components/ProductCard'
+import { useCart } from '../context/CartContext'
 
 export default function Product() {
   const { id } = useParams()
+  const { addItem } = useCart()
   const [product, setProduct] = useState(null)
   const [quantity, setQuantity] = useState(1)
   const [selectedSize, setSelectedSize] = useState('')
@@ -52,6 +54,12 @@ export default function Product() {
 
   const handleQuantityChange = (change) => {
     setQuantity(Math.max(1, quantity + change))
+  }
+
+  const handleAddToCart = () => {
+    if (product) {
+      addItem(product, quantity, selectedSize)
+    }
   }
 
   const reviews = [
@@ -198,7 +206,11 @@ export default function Product() {
               {/* Actions */}
               <div className="space-y-4">
                 <div className="flex gap-4">
-                  <Button size="lg" className="flex-1 bg-secondary hover:bg-secondary/90">
+                  <Button
+                    size="lg"
+                    className="flex-1 bg-secondary hover:bg-secondary/90"
+                    onClick={handleAddToCart}
+                  >
                     <ShoppingCart className="mr-2 h-5 w-5" />
                     Adicionar ao Carrinho
                   </Button>

--- a/ProductOptimized.jsx
+++ b/ProductOptimized.jsx
@@ -24,7 +24,7 @@ import productsOptimized from '../data/products_optimized'
 
 export default function ProductOptimized() {
   const { id } = useParams()
-  const { addToCart } = useCart()
+  const { addItem } = useCart()
   const [product, setProduct] = useState(null)
   const [selectedImage, setSelectedImage] = useState(0)
   const [selectedSize, setSelectedSize] = useState('')
@@ -42,11 +42,7 @@ export default function ProductOptimized() {
 
   const handleAddToCart = () => {
     if (product && selectedSize) {
-      addToCart({
-        ...product,
-        selectedSize,
-        quantity
-      })
+      addItem(product, quantity, selectedSize)
     }
   }
 


### PR DESCRIPTION
## Summary
- hook up product pages to cart context
- use `addItem` from `CartContext`
- make "Add to Cart" buttons functional

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d32ba239c8324916ff32afd9d046a