### PR TITLE
Fix cart function naming

### DIFF
--- a/ProductOptimized.jsx
+++ b/ProductOptimized.jsx
@@ -24,7 +24,7 @@ import productsOptimized from '../data/products_optimized'
 
 export default function ProductOptimized() {
   const { id } = useParams()
-  const { addToCart } = useCart()
+  const { addItem } = useCart()
   const [product, setProduct] = useState(null)
   const [selectedImage, setSelectedImage] = useState(0)
   const [selectedSize, setSelectedSize] = useState('')
@@ -42,7 +42,7 @@ export default function ProductOptimized() {
 
   const handleAddToCart = () => {
     if (product && selectedSize) {
-      addToCart({
+      addItem({
         ...product,
         selectedSize,
         quantity


### PR DESCRIPTION
## Summary
- rename `addToCart` calls to `addItem` in `ProductOptimized`

## Testing
- `npm run build` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d3874c22c8324a6790478f730cba7